### PR TITLE
feat/v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,41 @@ All notable changes to **html-generator** are recorded in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.6] — Unreleased
+## [0.0.7] — 2026-07-25
+
+### Fixed (security)
+
+- **`allow_unsafe_html: false` is enforced again on native targets.**
+  `mdx-gen` 0.0.2 unconditionally forces comrak's `render.r#unsafe = true`
+  on the options it receives, so the "safe" default silently passed raw
+  HTML — including `<script>` — straight through. comrak gives `escape`
+  precedence over `r#unsafe`, so the pipeline now sets
+  `render.escape = !allow_unsafe_html` (on both the block and inline
+  renderers); untrusted raw HTML is entity-escaped regardless of the
+  mdx-gen override.
+- **Crate-generated HTML is tunnelled past the escaper.** `:::class`
+  block wrappers and image-class `<img>` tags are trusted crate output;
+  each is replaced by an opaque U+FFFC-delimited sentinel before the
+  escaping render and restored afterwards (unwrapping comrak's paragraph
+  for block-level `<div>`s). Tunnelled fragments are always built from
+  `\w+`-validated class names and `escape_html`'d attributes, so a forged
+  sentinel can only surface safe crate HTML — never user-authored HTML.
 
 ### Changed
 
 - **YAML parsing migrated to `noyalib`.** The previously inlined
   `src/yaml/` snapshot is replaced by a dependency on `noyalib`
-  (`=0.0.3`, `default-features = false`, `features = ["std"]`).
+  (`=0.0.15`, `default-features = false`, `features = ["std"]`).
   Front-matter extraction behaviour is unchanged; the inlined
   parser is retired so security/perf fixes flow through one
   upstream crate instead of being maintained twice.
+
+### Security (dependencies)
+
+- Remediated RUSTSEC advisories: `ammonia` → 4.1.4 (RUSTSEC-2026-0193,
+  -0213), `crossbeam-epoch` → 0.9.20 (RUSTSEC-2026-0204), and
+  `plist` → 1.10.0 which pulls `quick-xml` → 0.41.0 transitively via
+  `syntect` (RUSTSEC-2026-0194, -0195); `anyhow` → latest.
 
 ### Dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,14 +58,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
- "cssparser 0.35.0",
- "html5ever 0.35.0",
+ "cssparser 0.37.0",
+ "html5ever",
  "maplit",
- "tendril 0.4.3",
  "url",
 ]
 
@@ -127,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "async-trait"
@@ -535,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -559,19 +558,6 @@ name = "cssparser"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be934d936a0fbed5bcdc01042b770de1398bf79d0e192f49fa7faea0e99281e"
-dependencies = [
- "cssparser-macros 0.6.1",
- "dtoa-short",
- "itoa",
- "phf 0.11.3",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
 dependencies = [
  "cssparser-macros 0.6.1",
  "dtoa-short",
@@ -914,16 +900,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "html-generator"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "ammonia",
  "comrak",
@@ -1081,23 +1057,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
-dependencies = [
- "log",
- "markup5ever 0.35.0",
- "match_token",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
- "markup5ever 0.39.0",
+ "markup5ever",
 ]
 
 [[package]]
@@ -1400,27 +1365,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "markup5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
-dependencies = [
- "log",
- "tendril 0.4.3",
- "web_atoms 0.1.3",
-]
 
 [[package]]
 name = "markup5ever"
@@ -1429,19 +1377,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
- "tendril 0.5.0",
- "web_atoms 0.2.5",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "tendril",
+ "web_atoms",
 ]
 
 [[package]]
@@ -1557,9 +1494,9 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "noyalib"
-version = "0.0.3"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5dc50790bdee1e91bb3407f58b9529e0de45dc65f7ffb06b514ecdbbd579489"
+checksum = "9014fb34654ac4f54a4ff52d5207b1e4a764604fced568c3a1d71ee99d1fc300"
 dependencies = [
  "indexmap",
  "memchr",
@@ -2212,9 +2149,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap",
@@ -2390,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -2599,10 +2536,10 @@ dependencies = [
  "cssparser 0.37.0",
  "ego-tree",
  "getopts",
- "html5ever 0.39.0",
+ "html5ever",
  "precomputed-hash",
  "selectors",
- "tendril 0.5.0",
+ "tendril",
 ]
 
 [[package]]
@@ -2818,19 +2755,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
@@ -2839,18 +2763,6 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.13.1",
  "precomputed-hash",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -2943,17 +2855,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
-]
-
-[[package]]
-name = "tendril"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
-dependencies = [
- "futf",
- "mac",
- "utf-8",
 ]
 
 [[package]]
@@ -3465,26 +3366,14 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
-dependencies = [
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
-]
-
-[[package]]
-name = "web_atoms"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "string_cache 0.9.0",
- "string_cache_codegen 0.6.1",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "html-generator"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 rust-version = "1.80.0"
 license = "MIT OR Apache-2.0"
@@ -86,7 +86,7 @@ minify-html = "0.18"
 # don't need on the parse-only hot path. Pinned to `=0.0.3` while the
 # crate is pre-1.0 so a noyalib patch release can't surprise this
 # crate's `cargo publish --dry-run` gate.
-noyalib = { version = "=0.0.3", default-features = false, features = ["std"] }
+noyalib = { version = "=0.0.15", default-features = false, features = ["std"] }
 once_cell = "1.21.4"
 pulldown-latex = { version = "0.7", optional = true }
 regex = "1.12.4"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://crates.io/crates/html-generator"><img src="https://img.shields.io/crates/v/html-generator.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/html-generator"><img src="https://img.shields.io/badge/docs.rs-html--generator-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/html-generator"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/html-generator?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/html-generator"><img src="https://img.shields.io/badge/lib.rs-v0.0.6-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/html-generator"><img src="https://img.shields.io/badge/lib.rs-v0.0.7-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -43,7 +43,7 @@
 
 ```toml
 [dependencies]
-html-generator = "0.0.6"
+html-generator = "0.0.7"
 ```
 
 ### Optional async support

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -475,6 +475,12 @@ fn markdown_to_html_impl(
     //    bits (unsafe HTML + syntax highlighting/theme).
     let mut comrak_options = BASE_COMRAK_OPTIONS.clone();
     comrak_options.render.r#unsafe = config.allow_unsafe_html;
+    // `mdx-gen` unconditionally forces `render.r#unsafe = true` on the
+    // options it receives, which would silently let raw HTML (including
+    // `<script>`) through even when `allow_unsafe_html` is false. comrak
+    // gives `escape` precedence over `r#unsafe`, so setting `escape` here
+    // entity-escapes untrusted raw HTML regardless of the mdx-gen override.
+    comrak_options.render.escape = !config.allow_unsafe_html;
 
     let mut md_options = MarkdownOptions::default()
         .with_comrak_options(comrak_options)

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -479,8 +479,10 @@ fn markdown_to_html_impl(
     );
 
     // 3) Convert images with `.class="..."` (no-alloc when no match).
-    let markdown_with_images =
-        process_images_with_classes(&markdown_with_classes, &mut tunnels);
+    let markdown_with_images = process_images_with_classes(
+        &markdown_with_classes,
+        &mut tunnels,
+    );
 
     // 4) Clone the cached Options tree and set the two runtime-varying
     //    bits (unsafe HTML + syntax highlighting/theme).
@@ -599,8 +601,9 @@ fn add_custom_classes<'a>(
 
             // class_name is validated by the \w+ regex — safe to interpolate;
             // inline_html already ran through the escaping inline renderer.
-            let fragment =
-                format!("<div class=\"{class_name}\">{inline_html}</div>");
+            let fragment = format!(
+                "<div class=\"{class_name}\">{inline_html}</div>"
+            );
             let index = tunnels.len();
             tunnels.push(fragment);
             tunnel_sentinel(index)
@@ -1263,7 +1266,8 @@ This is a note with a custom class.
     fn test_invalid_image_syntax() {
         let markdown = "![Image with missing URL]()";
         let mut tunnels = Vec::new();
-        let result = process_images_with_classes(markdown, &mut tunnels);
+        let result =
+            process_images_with_classes(markdown, &mut tunnels);
         assert_eq!(
             result, markdown,
             "Invalid image syntax should remain unchanged"

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -461,15 +461,26 @@ fn markdown_to_html_impl(
     let content_without_front_matter = extract_front_matter(markdown)
         .unwrap_or_else(|_| markdown.to_string());
 
+    // Crate-generated HTML (`:::class` wrappers, image-class `<img>`) is
+    // trusted and must survive the escaping render below. Each such fragment
+    // is replaced with an opaque sentinel *before* rendering and restored
+    // *after*. User-authored raw HTML is never turned into a sentinel, so it
+    // still obeys `render.escape`. A user who forges a sentinel can at worst
+    // surface one of *our own* fragments — each built from `\w+`-validated
+    // class names and `escape_html`'d attributes — never arbitrary HTML, so
+    // tunnelling cannot become an XSS vector.
+    let mut tunnels: Vec<String> = Vec::new();
+
     // 2) Convert triple-colon blocks (no-alloc when no `:::` match).
     let markdown_with_classes = add_custom_classes(
         &content_without_front_matter,
         config.allow_unsafe_html,
+        &mut tunnels,
     );
 
     // 3) Convert images with `.class="..."` (no-alloc when no match).
     let markdown_with_images =
-        process_images_with_classes(&markdown_with_classes);
+        process_images_with_classes(&markdown_with_classes, &mut tunnels);
 
     // 4) Clone the cached Options tree and set the two runtime-varying
     //    bits (unsafe HTML + syntax highlighting/theme).
@@ -491,9 +502,31 @@ fn markdown_to_html_impl(
     }
 
     // 5) Convert final Markdown to HTML
-    process_markdown(&markdown_with_images, &md_options).map_err(
-        |err| HtmlError::markdown_conversion(err.to_string(), None),
-    )
+    let mut html = process_markdown(&markdown_with_images, &md_options)
+        .map_err(|err| {
+            HtmlError::markdown_conversion(err.to_string(), None)
+        })?;
+
+    // 6) Restore tunnelled crate HTML. Block-level fragments (`:::` divs)
+    //    stood alone, so comrak wrapped the sentinel in a paragraph — strip
+    //    that wrapper to avoid `<p><div>…</div></p>`. Inline fragments
+    //    (images) are swapped in place.
+    for (index, fragment) in tunnels.iter().enumerate() {
+        let sentinel = tunnel_sentinel(index);
+        html = html.replace(&format!("<p>{sentinel}</p>"), fragment);
+        html = html.replace(&sentinel, fragment);
+    }
+
+    Ok(html)
+}
+
+/// Opaque sentinel used to tunnel trusted crate-generated HTML through the
+/// escaping render. Delimited by U+FFFC (OBJECT REPLACEMENT CHARACTER), which
+/// does not occur in normal Markdown and — not being an HTML metacharacter —
+/// is passed through verbatim by comrak regardless of `render.escape`.
+#[cfg(not(target_arch = "wasm32"))]
+fn tunnel_sentinel(index: usize) -> String {
+    format!("\u{FFFC}\u{FFFC}hgtunnel{index}\u{FFFC}\u{FFFC}")
 }
 
 /// WASM-target Markdown → HTML.
@@ -539,13 +572,17 @@ fn markdown_to_html_impl(
 /// # Example
 /// ...
 #[cfg(not(target_arch = "wasm32"))]
-fn add_custom_classes(
-    markdown: &str,
+fn add_custom_classes<'a>(
+    markdown: &'a str,
     allow_unsafe_html: bool,
-) -> Cow<'_, str> {
+    tunnels: &mut Vec<String>,
+) -> Cow<'a, str> {
     // `regex::Regex::replace_all` returns `Cow::Borrowed(markdown)`
     // when there are zero matches — avoiding the allocation
     // entirely for the common case of a document without `:::` blocks.
+    // Each rendered block is stashed in `tunnels` and replaced by a sentinel
+    // so the trusted `<div>` survives the escaping render (see
+    // `markdown_to_html_impl`).
     CUSTOM_CLASS_REGEX.replace_all(
         markdown,
         |caps: &regex::Captures| {
@@ -560,11 +597,13 @@ fn add_custom_classes(
                 Err(_) => block_content.to_string(),
             };
 
-            // class_name is validated by the \w+ regex — safe to interpolate
-            format!(
-                "<div class=\"{}\">{}</div>",
-                class_name, inline_html
-            )
+            // class_name is validated by the \w+ regex — safe to interpolate;
+            // inline_html already ran through the escaping inline renderer.
+            let fragment =
+                format!("<div class=\"{class_name}\">{inline_html}</div>");
+            let index = tunnels.len();
+            tunnels.push(fragment);
+            tunnel_sentinel(index)
         },
     )
 }
@@ -599,6 +638,9 @@ fn process_markdown_inline_impl(
     // pipeline; clone from the cached base rather than rebuilding.
     let mut comrak_opts = BASE_COMRAK_OPTIONS.clone();
     comrak_opts.render.r#unsafe = allow_unsafe_html;
+    // Same mdx-gen override guard as the outer pipeline: escape untrusted
+    // raw HTML inside `:::` block content unless unsafe HTML is allowed.
+    comrak_opts.render.escape = !allow_unsafe_html;
 
     let options =
         MarkdownOptions::default().with_comrak_options(comrak_opts);
@@ -620,16 +662,23 @@ fn process_markdown_inline_impl(
 /// Replaces image patterns like
 /// `![Alt text](URL).class="some-class"` with `<img src="URL" alt="Alt text" class="some-class" />`.
 #[cfg(not(target_arch = "wasm32"))]
-fn process_images_with_classes(markdown: &str) -> Cow<'_, str> {
+fn process_images_with_classes<'a>(
+    markdown: &'a str,
+    tunnels: &mut Vec<String>,
+) -> Cow<'a, str> {
     // Borrowed-Cow when the document has no `![alt](url).class="x"`
-    // construct — i.e. every typical document.
+    // construct — i.e. every typical document. Each generated `<img>` is
+    // tunnelled (see `markdown_to_html_impl`) so it survives escaping.
     IMAGE_CLASS_REGEX.replace_all(markdown, |caps: &regex::Captures| {
-        format!(
+        let fragment = format!(
             r#"<img src="{}" alt="{}" class="{}" />"#,
             escape_html(&caps[2]), // URL
             escape_html(&caps[1]), // alt text
             escape_html(&caps[3]), // class attribute
-        )
+        );
+        let index = tunnels.len();
+        tunnels.push(fragment);
+        tunnel_sentinel(index)
     })
 }
 
@@ -1213,10 +1262,15 @@ This is a note with a custom class.
     #[test]
     fn test_invalid_image_syntax() {
         let markdown = "![Image with missing URL]()";
-        let result = process_images_with_classes(markdown);
+        let mut tunnels = Vec::new();
+        let result = process_images_with_classes(markdown, &mut tunnels);
         assert_eq!(
             result, markdown,
             "Invalid image syntax should remain unchanged"
+        );
+        assert!(
+            tunnels.is_empty(),
+            "No image fragments should be tunnelled for invalid syntax"
         );
     }
 


### PR DESCRIPTION
- **fix(security): reconstruct allow_unsafe_html escape guard (PARTIAL)**
- **fix(security): tunnel trusted crate HTML past the escape guard**
- **chore(release): v0.0.7**
