### PR TITLE
chore(deps): consolidate dependency updates for v0.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "html-generator"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "ammonia",
  "comrak 0.54.0",
@@ -1408,14 +1408,15 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "noyalib"
-version = "0.0.17"
+version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179fb3ecf8e64246b67049033e61c739c467c7bb1d79b2c1a65c1ac13f87512a"
+checksum = "2d0ba37b65d8c94344cc44af197654bd0f270bf5729dad540c6eacf3447f50e0"
 dependencies = [
  "indexmap",
  "memchr",
  "rustc-hash",
  "serde",
+ "serde_core",
  "smallvec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "html-generator"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 rust-version = "1.80.0"
 license = "MIT OR Apache-2.0"
@@ -83,10 +83,10 @@ minify-html = "0.18"
 # Pure-Rust YAML parser used for front-matter extraction. Replaces the
 # previously inlined `src/yaml/` snapshot. `default-features = false`
 # with `["std"]` drops the `itoa`/`ryu` formatting accelerators we
-# don't need on the parse-only hot path. Pinned to `=0.0.3` while the
+# don't need on the parse-only hot path. Pinned exactly while the
 # crate is pre-1.0 so a noyalib patch release can't surprise this
 # crate's `cargo publish --dry-run` gate.
-noyalib = { version = "=0.0.17", default-features = false, features = ["std"] }
+noyalib = { version = "=0.0.19", default-features = false, features = ["std"] }
 once_cell = "1.21.4"
 pulldown-latex = { version = "0.8", optional = true }
 regex = "1.12.4"


### PR DESCRIPTION
Supersedes #62.

- `noyalib` `=0.0.17` -> `=0.0.19` (#62 proposed 0.0.18)
- version 0.0.8 -> 0.0.9

### Why 0.0.19 rather than 0.0.18

0.0.19 was published to crates.io on 2026-08-11 and is the current release — taking 0.0.18 would have meant re-bumping immediately.

It carries two fixes that matter to a consumer:

- `from_str_strict` rejected **every populated `Option` field, for every `T`** — not just the empty-string case it was reported as
- bare `nan` / `inf` scalar spellings resolved as floats and lost their original text, so a key like `nAn` did not round-trip

That second one is a **parse-behaviour change**, so the suite was the check that mattered: **631 tests pass unchanged**.

### The pin keeps its shape

```toml
noyalib = { version = "=0.0.19", default-features = false, features = ["std"] }
```

Exact pin and both flags preserved. A plain version replace would have dropped `default-features = false` and the `std` feature — which the comment above it explains are deliberate, dropping the `itoa`/`ryu` formatting accelerators this crate does not need on a parse-only path.

**Also corrected that comment:** it read *"Pinned to `=0.0.3`"*, which has been wrong since the pin moved off 0.0.3. It now states the intent without naming a version that will drift again.

### Verification

- `cargo check --locked --all-targets`: exit 0
- `cargo clippy --all-targets -- -D warnings`: exit 0
- `cargo test --all-features`: **631 passed, 0 failed**
- `cargo fmt --check`: clean