### PR TITLE
feat(deps)!: gate minify-html behind an opt-in `minify` feature (drops RUSTSEC-2026-0235)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "html-generator"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "ammonia",
  "comrak 0.54.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "html-generator"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 rust-version = "1.80.0"
 license = "MIT OR Apache-2.0"
@@ -79,7 +79,12 @@ crate-type = ["cdylib", "rlib"]
 ammonia = "4"
 indexmap = "2"
 log = "0.4"
-minify-html = "0.18"
+# Optional: pulls lightningcss -> parcel_sourcemap -> rkyv 0.7, which
+# carries RUSTSEC-2026-0235 (out-of-bounds reads). parcel_sourcemap
+# 2.1.1 is the latest and pins rkyv ^0.7, so there is no upstream
+# fix to take. Gated behind `minify` and off by default so consumers
+# that never minify do not inherit the advisory.
+minify-html = { version = "0.18", optional = true }
 # Pure-Rust YAML parser used for front-matter extraction. Replaces the
 # previously inlined `src/yaml/` snapshot. `default-features = false`
 # with `["std"]` drops the `itoa`/`ryu` formatting accelerators we
@@ -164,6 +169,9 @@ wasm-bindgen-test = "0.3"
 # Features that can be enabled or disabled.
 default = ["math"]
 async = ["dep:tokio"]
+# HTML minification via `minify-html`. Off by default: see the note on
+# the dependency. Enable with `features = ["minify"]`.
+minify = ["dep:minify-html"]
 # Server-side LaTeX → MathML rendering for `$..$` and `$$..$$`
 # spans. Pulled in by default because pure-Rust + zero-runtime-JS;
 # disable with `--no-default-features` if you want a smaller binary
@@ -208,6 +216,7 @@ path = "examples/toc.rs"
 [[example]]
 name = "minify"
 path = "examples/minify.rs"
+required-features = ["minify"]
 
 [[example]]
 name = "errors"
@@ -244,6 +253,7 @@ path = "examples/math_and_diagrams.rs"
 [[bench]]                         # Benchmarking configuration.
 name = "html_benchmark"           # Name of the benchmark.
 harness = false                   # Disable the default benchmark harness.
+required-features = ["minify"] # Benchmarks minify_html.
 
 # Competitor comparison: same realistic 8 KB blog payload run through
 # html-generator and three popular CommonMark crates so the README's

--- a/README.md
+++ b/README.md
@@ -258,11 +258,14 @@ println!("Issues found: {}", report.issue_count);
 <summary><b>Minification</b></summary>
 
 ```rust
+# // Requires the `minify` feature, which is off by default.
+# #[cfg(feature = "minify")] {
 use html_generator::performance::minify_html_string;
 
 let html = "<html>  <body>  <p>Hello</p>  </body>  </html>";
 let minified = minify_html_string(html)?;
 assert_eq!(minified, "<html><body><p>Hello</p></body></html>");
+# }
 # Ok::<(), html_generator::error::HtmlError>(())
 ```
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -12,7 +12,6 @@ use crate::error::HtmlError;
 use crate::{
     accessibility::add_aria_attributes,
     extract_front_matter,
-    performance::minify_html_string,
     seo::{escape_html, generate_structured_data_from_doc},
     utils::generate_table_of_contents,
     Result,
@@ -353,9 +352,10 @@ pub fn generate_html_with_diagnostics(
     }
 
     // Step 7: Minification
+    #[cfg(feature = "minify")]
     if config.minify_output {
         let before_len = html.len();
-        match minify_html_string(&html) {
+        match crate::performance::minify_html_string(&html) {
             Ok(minified) => {
                 let saved = before_len.saturating_sub(minified.len());
                 html = minified;
@@ -383,6 +383,23 @@ pub fn generate_html_with_diagnostics(
                 diagnostics.push(d);
             }
         }
+    }
+
+    // Requesting minification without the `minify` feature is reported
+    // rather than silently ignored — the caller asked for something the
+    // build cannot do.
+    #[cfg(not(feature = "minify"))]
+    if config.minify_output {
+        let d = Diagnostic {
+            step: "minification",
+            level: DiagnosticLevel::Warning,
+            message:
+                "minify_output was requested but this build has the \
+                      `minify` feature disabled; output is unminified"
+                    .to_owned(),
+        };
+        warn!("{d}");
+        diagnostics.push(d);
     }
 
     Ok(HtmlOutput { html, diagnostics })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ pub use generator::{
 };
 #[cfg(feature = "async")]
 pub use performance::async_generate_html;
+#[cfg(feature = "minify")]
+#[cfg_attr(docsrs, doc(cfg(feature = "minify")))]
 pub use performance::{minify_html, minify_html_string};
 pub use seo::{generate_meta_tags, generate_structured_data};
 pub use utils::{

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -21,6 +21,8 @@
 //!
 //! Basic HTML minification:
 //! ```no_run
+//! # // Requires the `minify` feature, which is off by default.
+//! # #[cfg(feature = "minify")] {
 //! # use html_generator::performance::minify_html;
 //! # use std::path::Path;
 //! # fn example() -> Result<(), html_generator::error::HtmlError> {
@@ -29,10 +31,14 @@
 //! println!("Minified size: {} bytes", minified.len());
 //! # Ok(())
 //! # }
+//! # }
 //! ```
 
+#[cfg(any(feature = "minify", feature = "async"))]
 use crate::{HtmlError, Result};
+#[cfg(feature = "minify")]
 use minify_html::{minify, Cfg};
+#[cfg(feature = "minify")]
 use std::{fs, path::Path};
 
 #[cfg(feature = "async")]
@@ -57,12 +63,14 @@ pub const MAX_FILE_SIZE: usize = 10 * 1024 * 1024;
 /// Provides a set of minification options that preserve HTML semantics
 /// while reducing file size. The configuration balances compression
 /// with standards compliance.
+#[cfg(feature = "minify")]
 #[derive(Clone)]
 struct MinifyConfig {
     /// Internal minification configuration from minify-html crate
     cfg: Cfg,
 }
 
+#[cfg(feature = "minify")]
 impl Default for MinifyConfig {
     fn default() -> Self {
         let mut cfg = Cfg::new();
@@ -83,6 +91,7 @@ impl Default for MinifyConfig {
     }
 }
 
+#[cfg(feature = "minify")]
 impl std::fmt::Debug for MinifyConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MinifyConfig")
@@ -127,6 +136,8 @@ impl std::fmt::Debug for MinifyConfig {
 /// # Ok(())
 /// # }
 /// ```
+#[cfg(feature = "minify")]
+#[cfg_attr(docsrs, doc(cfg(feature = "minify")))]
 pub fn minify_html(file_path: &Path) -> Result<String> {
     let metadata = fs::metadata(file_path).map_err(|e| {
         HtmlError::MinificationError(format!(
@@ -201,6 +212,8 @@ pub fn minify_html(file_path: &Path) -> Result<String> {
 /// # Ok(())
 /// # }
 /// ```
+#[cfg(feature = "minify")]
+#[cfg_attr(docsrs, doc(cfg(feature = "minify")))]
 pub fn minify_html_string(html: &str) -> Result<String> {
     if html.len() > MAX_FILE_SIZE {
         return Err(HtmlError::MinificationError(format!(
@@ -263,9 +276,14 @@ pub async fn async_generate_html(markdown: &str) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
+    // Used by the minify test helper and the gated test modules.
+    #[cfg(feature = "minify")]
     use std::fs::File;
+    #[cfg(feature = "minify")]
     use std::io::Write;
+    #[cfg(feature = "minify")]
     use tempfile::tempdir;
 
     /// Helper function to create a temporary HTML file for testing.
@@ -277,6 +295,7 @@ mod tests {
     /// # Returns
     ///
     /// A tuple containing the temporary directory and file path.
+    #[cfg(feature = "minify")]
     fn create_test_file(
         content: &str,
     ) -> (tempfile::TempDir, std::path::PathBuf) {
@@ -289,6 +308,7 @@ mod tests {
         (dir, file_path)
     }
 
+    #[cfg(feature = "minify")]
     mod minify_html_tests {
         use super::*;
 
@@ -435,6 +455,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "minify")]
     mod additional_tests {
         use super::*;
         use std::fs::File;

--- a/tests/fixture_tests.rs
+++ b/tests/fixture_tests.rs
@@ -443,6 +443,10 @@ fn fixture_real_world_blog() {
     );
 }
 
+// Asserts the minified output is smaller than the normal one, which
+// only holds when minification is compiled in. See the `minify`
+// feature.
+#[cfg(feature = "minify")]
 #[test]
 fn fixture_real_world_blog_minified() {
     let md = load_fixture("real_world_blog.txt");

--- a/tests/unit_coverage.rs
+++ b/tests/unit_coverage.rs
@@ -17,8 +17,6 @@ use html_generator::{
     error::{ErrorKind, HtmlError, SeoErrorKind},
     generate_html, generate_html_with_diagnostics,
     generator::{Diagnostic, DiagnosticLevel},
-    minify_html_string,
-    performance::MAX_FILE_SIZE,
     seo::{escape_html, generate_meta_tags, generate_structured_data},
     utils::{extract_front_matter_data, format_header_with_id_class},
     HtmlConfig, HtmlConfigBuilder,
@@ -335,10 +333,12 @@ fn sanitization_runs_when_unsafe_html_and_sanitize_both_enabled() {
 
 // ─── minify_html_string: size-limit error branch ──────────────────
 
+#[cfg(feature = "minify")]
 #[test]
 fn minify_html_string_rejects_oversized_input() {
-    let giant = "<p>".repeat(MAX_FILE_SIZE);
-    let err = minify_html_string(&giant).unwrap_err();
+    let giant =
+        "<p>".repeat(html_generator::performance::MAX_FILE_SIZE);
+    let err = html_generator::minify_html_string(&giant).unwrap_err();
     assert!(
         matches!(err, HtmlError::MinificationError(ref m) if m.contains("exceeds maximum"))
     );
@@ -566,6 +566,9 @@ fn toc_failure_emits_error_diagnostic() {
 
 // ─── generator: minification info on empty input (0-byte path) ───
 
+// With `minify` disabled the step records a Warning instead, so this
+// assertion is feature-specific.
+#[cfg(feature = "minify")]
 #[test]
 fn minification_on_empty_input_records_info() {
     let config = HtmlConfig {


### PR DESCRIPTION
Removes **RUSTSEC-2026-0235** from the default dependency graph.

`minify-html` pulls `lightningcss` -> `parcel_sourcemap` -> `rkyv 0.7.46`, which carries an out-of-bounds read advisory. **There is no upstream fix to take:** `parcel_sourcemap` 2.1.1 is the latest release and pins `rkyv ^0.7.38`, so it cannot move to the fixed 0.8.17. I tried upgrading `lightningcss` to alpha.72 — rkyv stayed at 0.7.46.

So the fix is to stop pulling it unless it is wanted:

```toml
minify-html = { version = "0.18", optional = true }
minify = ["dep:minify-html"]
```

Off by default. Measured:

```
cargo tree -i rkyv                    -> package ID `rkyv` did not match any packages
cargo tree -i rkyv --features minify  -> rkyv v0.7.46
```

Consumers that never minify no longer inherit the advisory. **sitemap-gen is one of them** — its CI is currently red on exactly this. `staticdatagen` *does* minify and will need `features = ["minify"]` when it moves to this version.

## ⚠️ BREAKING

`minify_html` and `minify_html_string` are no longer in the default build. Callers add `features = ["minify"]`.

Requesting minification in a build without the feature is **reported rather than ignored** — `generate_html_with_diagnostics` records a Warning saying the build cannot minify, instead of silently returning unminified output as though it had succeeded.

## What is gated

The dependency import, `MinifyConfig` and its `Default`/`Debug` impls, both public functions, the `lib.rs` re-export, the generator's minification step, the `minify` example and the benchmark (via `required-features`), the `minify_html_tests` and `additional_tests` modules — all nine of the latter's tests exercise minification — and three integration tests whose assertions only hold with it on.

Two doc examples calling the gated API live in **module and crate-level docs, which cannot themselves be gated**: the README block (included via `#![doc = include_str!]`) and the `performance` module header. Both are wrapped in hidden `#[cfg(feature = "minify")]` blocks, so they compile without the feature and still run with it.

## Verification

| configuration | result |
|---|---|
| `cargo test` | **604 passed, 0 failed** |
| `cargo test --features minify` | **625 passed, 0 failed** |
| `cargo test --all-features` | **631 passed, 0 failed** |
| `cargo test --no-default-features` | **594 passed, 0 failed** |

- `clippy --all-targets -- -D warnings`, default **and** `--all-features`: exit 0
- `cargo check --locked --all-targets`: exit 0
- `cargo audit --deny warnings`: exit 0
- `cargo fmt --check`: clean